### PR TITLE
T3.5 & T2.5 Mex Tweaking/Support

### DIFF
--- a/lua/AI/M28Economy.lua
+++ b/lua/AI/M28Economy.lua
@@ -3111,7 +3111,7 @@ function ConsiderFutureMexUpgrade(oMex, iOverrideSecondsToWait)
             elseif aiBrain[refiGrossMassBaseIncome] < 5 and iMexesOnMap <= 60 and M28UnitInfo.GetUnitLifetimeCount(oMex) <= 4 then
                 iTimeToWait = 2 * 60 + 2 * 60 * (10-aiBrain[refiGrossMassBaseIncome]) / 10
             else
-                iTimeToWait = 8 * 60
+                iTimeToWait = 4 * 60
             end
         else --redundancy
             local tLZData = M28Map.GetLandOrWaterZoneData(oMex:GetPosition())
@@ -3329,7 +3329,7 @@ function ConsiderUpgradingMexDueToCompletion(oJustBuilt, oOptionalEngineer)
                             if (M28Utilities.IsTableEmpty(tLZOrWZTeamData[M28Map.subrefTEnemyUnits]) or ((tLZOrWZTeamData[M28Map.subrefTThreatEnemyCombatTotal] or 100) <= 2)) and (tLZOrWZTeamData[M28Map.refiEnemyAirToGroundThreat] or 0) == 0 and M28Utilities.IsTableEmpty(oJustBuilt[M28Building.reftTMLInRangeOfThisUnit]) and M28Utilities.IsTableEmpty(tLZOrWZTeamData[M28Map.subreftoAllNearbyEnemyT2ArtiUnits]) and (tLZOrWZTeamData[M28Map.subrefiNearbyEnemyLongRangeDFThreat] or 0) == 0 then
                                 --Upgrade another mex in this zone (or this mex if T3 LOUD)
                                 bTryingToUpgradeMex = true
-                                if iMexTechLevel >= 3 and not((oJustBuilt:GetBlueprint().General.UpgradesTo or '') == '') then
+                                if iMexTechLevel >= 3 and not((oJustBuilt:GetBlueprint().General.UpgradesTo or '') == '') and not M28Utilities.bQuietModActive then -- Only want to rush T3.5 Mex upgrade if LOUD
                                     if bDebugMessages == true then LOG(sFunctionRef..': Upgrading this unit again') end
                                     UpgradeUnit(oJustBuilt, true)
                                 elseif M28Utilities.IsTableEmpty(tLZOrWZTeamData[M28Map.subreftoLZOrWZAlliedUnits]) == false then --redundancy

--- a/lua/AI/M28Economy.lua
+++ b/lua/AI/M28Economy.lua
@@ -3082,8 +3082,16 @@ function ConsiderFutureMexUpgrade(oMex, iOverrideSecondsToWait)
                     iTimeToWait = iTimeToWait - 20
                 end
             end
-        elseif bT3MexCanBeUpgraded and (M28Utilities.bLoudModActive or M28Utilities.bQuietModActive) and iMexTechLevel == 3 then
+        elseif bT3MexCanBeUpgraded and (M28Utilities.bLoudModActive and not M28Utilities.bQuietModActive) and iMexTechLevel == 3 then
             iTimeToWait = 0
+        elseif bT3MexCanBeUpgraded and M28Utilities.bQuietModActive and iMexTechLevel == 3 then
+            if aiBrain[refiGrossMassBaseIncome] < 10 or iMexesOnMap > 20 * M28Team.tTeamData[iTeam][M28Team.subrefiActiveM28BrainCount] then
+                iTimeToWait = 4 * 60 + 4 * 60 * (10 - aiBrain[refiGrossMassBaseIncome]) / 10
+            elseif aiBrain[refiGrossMassBaseIncome] < 5 and iMexesOnMap <= 60 and M28UnitInfo.GetUnitLifetimeCount(oMex) <= 4 then
+                iTimeToWait = 2 * 60 + 2 * 60 * (25-aiBrain[refiGrossMassBaseIncome]) / 10
+            else
+                iTimeToWait = 8 * 60
+            end
         else --redundancy
             local tLZData = M28Map.GetLandOrWaterZoneData(oMex:GetPosition())
             local iMexesInZone = (tLZData[M28Map.subrefLZMexCount] or 0)

--- a/lua/AI/M28Economy.lua
+++ b/lua/AI/M28Economy.lua
@@ -3004,8 +3004,21 @@ function ConsiderFutureMexUpgrade(oMex, iOverrideSecondsToWait)
     local iTeam = aiBrain.M28Team
     local tLZOrWZData, tLZOrWZTeamData
     local iMexesOnMap = table.getn(M28Map.tMassPoints)
+    -- QUIET T2.5 MEXES
+    -- need Maudlin28 in-place on T2.5 stuff
+    local tQuietT25MexUnitIds = {
+        'UAB1204',
+        'UEB1204',
+        'URB1204',
+        'XSB1204',
+    }
 
-
+    local function IsQuietT25Mex(unitId)
+        for _, id in tQuietT25MexUnitIds do
+            if id == unitId then return true end
+        end
+        return false
+    end
 
     if iPlateauOrZero == 0 then
         tLZOrWZData = M28Map.tPondDetails[M28Map.tiPondByWaterZone[iLandOrWaterZone]][M28Map.subrefPondWaterZones][iLandOrWaterZone]
@@ -3067,7 +3080,7 @@ function ConsiderFutureMexUpgrade(oMex, iOverrideSecondsToWait)
             else
                 iTimeToWait = 7 * 60
             end
-        elseif iMexTechLevel == 2 then
+        elseif iMexTechLevel == 2 and not IsQuietT25Mex(oMex.UnitId) then
             if aiBrain[refiGrossMassBaseIncome] < 10 and (not(M28Utilities.bLoudModActive or M28Utilities.bQuietModActive) or iMexesOnMap > 20 * M28Team.tTeamData[iTeam][M28Team.subrefiActiveM28BrainCount]) then
                 iTimeToWait = 8 * 60 + 4 * 60 * (10-aiBrain[refiGrossMassBaseIncome]) / 10
             elseif aiBrain[refiGrossMassBaseIncome] < 5 and iMexesOnMap <= 60 and M28UnitInfo.GetUnitLifetimeCount(oMex) <= 3 then --Prioritise first few t3 mex upgrades
@@ -3082,13 +3095,21 @@ function ConsiderFutureMexUpgrade(oMex, iOverrideSecondsToWait)
                     iTimeToWait = iTimeToWait - 20
                 end
             end
+        elseif iMexTechLevel == 2 and M28Utilities.bQuietModActive and IsQuietT25Mex(oMex.UnitId) then
+            if aiBrain[refiGrossMassBaseIncome] < 10 or iMexesOnMap > 20 * M28Team.tTeamData[iTeam][M28Team.subrefiActiveM28BrainCount] then
+                iTimeToWait = 2 * 60 + 4 * 60 * (10-aiBrain[refiGrossMassBaseIncome]) / 10
+            elseif aiBrain[refiGrossMassBaseIncome] < 5 and iMexesOnMap <= 60 and M28UnitInfo.GetUnitLifetimeCount(oMex) <= 3 then
+                iTimeToWait = 1 * 60 + 2 * 60 * (10-aiBrain[refiGrossMassBaseIncome]) / 10
+            else
+                iTimeToWait = 4 * 60
+            end
         elseif bT3MexCanBeUpgraded and (M28Utilities.bLoudModActive and not M28Utilities.bQuietModActive) and iMexTechLevel == 3 then
             iTimeToWait = 0
         elseif bT3MexCanBeUpgraded and M28Utilities.bQuietModActive and iMexTechLevel == 3 then
             if aiBrain[refiGrossMassBaseIncome] < 10 or iMexesOnMap > 20 * M28Team.tTeamData[iTeam][M28Team.subrefiActiveM28BrainCount] then
                 iTimeToWait = 4 * 60 + 4 * 60 * (10 - aiBrain[refiGrossMassBaseIncome]) / 10
             elseif aiBrain[refiGrossMassBaseIncome] < 5 and iMexesOnMap <= 60 and M28UnitInfo.GetUnitLifetimeCount(oMex) <= 4 then
-                iTimeToWait = 2 * 60 + 2 * 60 * (25-aiBrain[refiGrossMassBaseIncome]) / 10
+                iTimeToWait = 2 * 60 + 2 * 60 * (10-aiBrain[refiGrossMassBaseIncome]) / 10
             else
                 iTimeToWait = 8 * 60
             end


### PR DESCRIPTION
Updated Economic Stuff to support QUIET Economy much better as I noticed M28 starting to perform a lil worst because hes rushing T3.5 Mexes too early and not upgrading enough T2.5 Mexes before going into T3.

T2.5 Mexes cost the amount that 4 T1 Mass Storage would iirc.
T3.5 Mexes are about 5000 mass so the context would be staying T3 much longer then normal.