### PR TITLE
fix: accumulate T2/T3 power counts across all team brains in ConsiderReclaimingPower

### DIFF
--- a/lua/AI/M28Economy.lua
+++ b/lua/AI/M28Economy.lua
@@ -1305,7 +1305,7 @@ function ConsiderReclaimingPower(iTeam, oPowerJustBuilt)
             --Check we have 1 T2 power per M28 player
             local iT2PowerEquivalent = 0
             for iBrain, oBrain in M28Team.tTeamData[iTeam][M28Team.subreftoFriendlyActiveM28Brains] do
-                iT2PowerEquivalent = oBrain:GetCurrentUnits(M28UnitInfo.refCategoryPower * categories.TECH2) + oBrain:GetCurrentUnits(M28UnitInfo.refCategoryPower * categories.TECH3) * 4
+                iT2PowerEquivalent = iT2PowerEquivalent + oBrain:GetCurrentUnits(M28UnitInfo.refCategoryPower * categories.TECH2) + oBrain:GetCurrentUnits(M28UnitInfo.refCategoryPower * categories.TECH3) * 4
             end
             if iT2PowerEquivalent >= M28Team.tTeamData[iTeam][M28Team.subrefiActiveM28BrainCount] * 0.65 or M28Team.tTeamData[iTeam][M28Team.subrefiTeamGrossEnergy] >= 1000 * M28Team.tTeamData[iTeam][M28Team.subrefiActiveM28BrainCount] * M28Team.tTeamData[iTeam][M28Team.refiHighestBrainResourceMultiplier] then
                 if iT2PowerEquivalent >= 2 then M28Team.tTeamData[iTeam][M28Team.refbFocusOnT1Spam] = false end --If game is late enough that we have built multiple t2 pgens then should start ecoing
@@ -1320,7 +1320,7 @@ function ConsiderReclaimingPower(iTeam, oPowerJustBuilt)
         if not(M28Team.tTeamData[iTeam][M28Team.subrefbActiveT2PowerReclaimer]) then
             local iT3PowerEquivalent = 0
             for iBrain, oBrain in M28Team.tTeamData[iTeam][M28Team.subreftoFriendlyActiveM28Brains] do
-                iT3PowerEquivalent = oBrain:GetCurrentUnits(M28UnitInfo.refCategoryPower * categories.TECH3)
+                iT3PowerEquivalent = iT3PowerEquivalent + oBrain:GetCurrentUnits(M28UnitInfo.refCategoryPower * categories.TECH3)
             end
             if not(M28Utilities.bLoudModActive or M28Utilities.bQuietModActive) and M28Team.tTeamData[iTeam][M28Team.subrefiTeamGrossEnergy] >= 600 * M28Team.tTeamData[iTeam][M28Team.subrefiActiveM28BrainCount] * 0.65 * M28Team.tTeamData[iTeam][M28Team.refiHighestBrainResourceMultiplier] and (iT3PowerEquivalent >= M28Team.tTeamData[iTeam][M28Team.subrefiActiveM28BrainCount] or M28Team.tTeamData[iTeam][M28Team.subrefiTeamGrossEnergy] >= 2000 * M28Team.tTeamData[iTeam][M28Team.subrefiActiveM28BrainCount] * M28Team.tTeamData[iTeam][M28Team.refiHighestBrainResourceMultiplier]) then
                 M28Profiler.FunctionProfiler(sFunctionRef, M28Profiler.refProfilerEnd)


### PR DESCRIPTION
In team games (2v2+), `iT2PowerEquivalent` and `iT3PowerEquivalent` in `ConsiderReclaimingPower` (M28Economy.lua, lines 1308 and 1323) are overwritten each loop iteration instead of accumulated:

```lua
-- Before (overwrites — only last brain counted):
iT2PowerEquivalent = oBrain:GetCurrentUnits(...)
iT3PowerEquivalent = oBrain:GetCurrentUnits(...)

-- After (accumulates across all team brains):
iT2PowerEquivalent = iT2PowerEquivalent + oBrain:GetCurrentUnits(...)
iT3PowerEquivalent = iT3PowerEquivalent + oBrain:GetCurrentUnits(...)
```

This means only the last allied brain's power plants are counted, causing the AI to underestimate total team power and delay reclaiming obsolete T1 generators.

The same accumulation pattern is used correctly elsewhere in the file (e.g. `iCurEngis` line 1626, `iTotalEnergyStored` line 2911).

No effect in 1v1 (single brain = single iteration).