### PR TITLE
fix: GetAverageOfUnitPositions Z accumulator uses tTotalPos[1] instead of [3]

### DIFF
--- a/lua/AI/M28Utilities.lua
+++ b/lua/AI/M28Utilities.lua
@@ -857,7 +857,7 @@ function GetAverageOfUnitPositions(tUnits)
     for iUnit, oUnit in tUnits do
         if not(oUnit.Dead) then
             tTotalPos[1] = tTotalPos[1] + oUnit:GetPosition()[1]
-            tTotalPos[3] = tTotalPos[1] + oUnit:GetPosition()[3]
+            tTotalPos[3] = tTotalPos[3] + oUnit:GetPosition()[3]
             iLocationCount = iLocationCount + 1
         end
     end


### PR DESCRIPTION
M28Utilities.lua line 860: `tTotalPos[3] = tTotalPos[1] + oUnit:GetPosition()[3]` should be `tTotalPos[3] = tTotalPos[3] + ...`

Copy-paste from the line above. The Z average ends up containing accumulated X values instead of Z. Compare with `GetAverageOfLocations` directly below which does it correctly.